### PR TITLE
Update MLflow image to 3.10.1

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -3,7 +3,6 @@ on:
   release:
     types: [published]
 
-
 jobs:
   build-publish:
     runs-on: ubuntu-latest
@@ -23,11 +22,34 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract pinned MLflow version
+        id: mlflow_version
+        run: |
+          version="$(grep '^mlflow==' requirements.txt | cut -d= -f3)"
+          if [ -z "$version" ]; then
+            echo "Unable to determine pinned MLflow version from requirements.txt"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag matches MLflow version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          MLFLOW_VERSION: ${{ steps.mlflow_version.outputs.version }}
+        run: |
+          if [ "$RELEASE_TAG" != "$MLFLOW_VERSION" ]; then
+            echo "Release tag '$RELEASE_TAG' must match pinned MLflow version '$MLFLOW_VERSION'"
+            exit 1
+          fi
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: keanrawr/mlflow-server
+          tags: |
+            type=raw,value=${{ steps.mlflow_version.outputs.version }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Extract pinned MLflow version
         id: mlflow_version
         run: |
-          version="$(grep '^mlflow==' requirements.txt | cut -d= -f3)"
+          version="$(sed -n 's/^mlflow==\([^[:space:]#]*\).*$/\1/p' requirements.txt)"
           if [ -z "$version" ]; then
             echo "Unable to determine pinned MLflow version from requirements.txt"
             exit 1

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Very over-simplistic way to publish a docker image with the dependencies needed 
 
 This image is intended to be used through `docker compose`. I am going to deploy this using portainer in my homelab.
 
+Published image tags match the pinned MLflow version in `requirements.txt`. For example, if the repo pins `mlflow==3.10.1`, the GitHub release tag and Docker Hub tag should also be `3.10.1`.
+
 Example docker compose:
 
 ```yaml
@@ -32,8 +34,7 @@ services:
       - dbdata:/var/lib/postgresql/data
   mlflow:
     restart: unless-stopped
-    build: .
-    image: mlflow_server
+    image: keanrawr/mlflow-server:3.10.1
     depends_on:
       db:
         condition: service_healthy
@@ -49,3 +50,5 @@ volumes:
     dbdata:
 
 ```
+
+For local development, replace the `image:` line with `build: .` if you want Compose to build the image from the checked-out repo.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mlflow==3.9.0
+mlflow==3.10.1
 boto3==1.42.42
 psycopg2-binary==2.9.11


### PR DESCRIPTION
## Summary
- bump the pinned MLflow version to 3.10.1
- make image publishing derive Docker tags from the pinned MLflow version
- fail releases when the GitHub release tag does not match the pinned MLflow version
- update the README example to reflect published image tags

## Testing
- git diff --check
- docker build -t mlflow-server:test .

Closes INS-5