### PR TITLE
ci: change dependabot schedule from daily to weekly on Mondays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,5 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
Changes Dependabot to check for dependency updates weekly on Mondays instead of daily.